### PR TITLE
Fix tcgapi.py _debugPackets property API.

### DIFF
--- a/TCGstorageAPI/tcgapi.py
+++ b/TCGstorageAPI/tcgapi.py
@@ -311,10 +311,17 @@ class Sed(object):
     @property
     def _debugPackets(self):
         '''
-        Dump TCG packets in debug log
+        Retrieve flag for dumping TCG packets in debug log.
         '''
 
-        self.__pysed._debugPackets
+        return self.__pysed._debugPackets
+
+    @_debugPackets.setter
+    def _debugPackets(self, value):
+        '''
+        Toggle flag to enable dumping TCG packets in debug log.
+        '''
+        self.__pysed._debugPackets = value
     
     @property
     def fipsApprovedMode(self):

--- a/pysed/TcgDrive.cpp
+++ b/pysed/TcgDrive.cpp
@@ -457,7 +457,7 @@ void Session::dumpPacket(const char * desc, void * buf, size_t size) {
 	}
 	if (strlen(bytestr)) {
 		// dump whatever remains in the string buffer
-		getLogger().debug("dump[%s][%d]: %s", desc, lastprint, bytestr);
+		getLogger().debug("%s [%d]: %s", desc, lastprint, bytestr);
 	}
 }
 

--- a/pysed/TcgDrive.cpp
+++ b/pysed/TcgDrive.cpp
@@ -441,10 +441,24 @@ void Session::dumpPacket(const char * desc, void * buf, size_t size) {
 	if (dumpPackets == false)
 		return;
 
-	LoggerBase & logger = drive->getLogger();
-	std::string dump = drive->getLogger().dump(buf, size).c_str();
-	dump = std::string(desc) + std::string(":") + dump;
-	logger.write(LoggerBase::Debug, dump.c_str());
+	unsigned char *bytes = (unsigned char *)buf;
+	int maxbytes = size * 5 + 1;
+	int lastprint = 0;
+	char bytestr[maxbytes];
+	bzero(bytestr, sizeof(bytestr));
+	for (int i = 0; i < size; i++) {
+		int currlen = strlen(bytestr);
+		sprintf(bytestr + currlen, "0x%02x ", bytes[i]);
+		if (strlen(bytestr) > 76) {
+			getLogger().debug("%s [%d]: %s", desc, i, bytestr);
+			bzero(bytestr, sizeof(bytestr));
+			lastprint = i + 1;
+		}
+	}
+	if (strlen(bytestr)) {
+		// dump whatever remains in the string buffer
+		getLogger().debug("dump[%s][%d]: %s", desc, lastprint, bytestr);
+	}
 }
 
 void PacketHeaders::fill(Drive * const drive, Session * const session,

--- a/pysed/TcgDrive.cpp
+++ b/pysed/TcgDrive.cpp
@@ -450,7 +450,7 @@ void Session::dumpPacket(const char * desc, void * buf, size_t size) {
 		int currlen = strlen(bytestr);
 		sprintf(bytestr + currlen, "0x%02x ", bytes[i]);
 		if (strlen(bytestr) > 76) {
-			getLogger().debug("%s [%d]: %s", desc, i, bytestr);
+			getLogger().debug("%s [%d]: %s", desc, lastprint, bytestr);
 			bzero(bytestr, sizeof(bytestr));
 			lastprint = i + 1;
 		}


### PR DESCRIPTION
- Fixes pysed/tcgapi.py bug to properly expose the _debugPackets property
- Fixes the TcgDrive.cpp Session::dumpPacket function to properly dump binary packets without choking on UTF-8.

Signed-off-by: wyllys <wyllys.ingersoll@keepertech.com>

